### PR TITLE
Add txcd script

### DIFF
--- a/scripts/.bin/txcd
+++ b/scripts/.bin/txcd
@@ -30,7 +30,7 @@ if [ -z "${TMUX:-}" ]; then
 
   # Create new session with a locked "root" window, then attach
   tmux new-session -d -s "$SESSION_NAME" -n "root" -c "$ABS_PATH"
-  tmux set-window-option -t "$SESSION_NAME:root" automatic-rename off
+  tmux set-window-option -t "=$SESSION_NAME:root" automatic-rename off
   exec tmux attach-session -t "=$SESSION_NAME"
 fi
 

--- a/scripts/.bin/txcd
+++ b/scripts/.bin/txcd
@@ -10,13 +10,13 @@ fi
 
 TARGET="$1"
 
-if [ -z "${TMUX:-}" ]; then
+# Resolve/create the directory (shared by both branches)
+if [ ! -d "$TARGET" ]; then
+  mkdir -p -- "$TARGET"
+fi
+ABS_PATH="$(cd "$TARGET" && pwd)"
 
-  # Resolve/create the directory before starting the session
-  if [ ! -d "$TARGET" ]; then
-    mkdir -p -- "$TARGET"
-  fi
-  ABS_PATH="$(cd "$TARGET" && pwd)"
+if [ -z "${TMUX:-}" ]; then
   SESSION_NAME="$(basename "$ABS_PATH")"
 
   # Attach to existing session if one already exists with this name
@@ -29,14 +29,6 @@ if [ -z "${TMUX:-}" ]; then
   tmux set-window-option -t "$SESSION_NAME:root" automatic-rename off
   exec tmux attach-session -t "$SESSION_NAME"
 fi
-
-# Create directory if it doesn't exist
-if [ ! -d "$TARGET" ]; then
-  mkdir -p -- "$TARGET"
-fi
-
-# Resolve absolute path
-ABS_PATH="$(cd "$TARGET" && pwd)"
 
 # Get the session root directory
 SESSION_ROOT="$(tmux display-message -p "#{session_path}")"

--- a/scripts/.bin/txcd
+++ b/scripts/.bin/txcd
@@ -46,8 +46,9 @@ else
   WINDOW_NAME="$ABS_PATH"
 fi
 
-# If a window with this name already exists, switch to it
+# If a window with this name already exists, switch to it and lock the name
 if tmux select-window -t "=$WINDOW_NAME" 2>/dev/null; then
+  tmux set-window-option -t "=$WINDOW_NAME" automatic-rename off
   exit 0
 fi
 

--- a/scripts/.bin/txcd
+++ b/scripts/.bin/txcd
@@ -8,12 +8,27 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 
-if [ -z "${TMUX:-}" ]; then
-  echo "txcd: must be run inside a tmux session" >&2
-  exit 1
-fi
-
 TARGET="$1"
+
+if [ -z "${TMUX:-}" ]; then
+
+  # Resolve/create the directory before starting the session
+  if [ ! -d "$TARGET" ]; then
+    mkdir -p -- "$TARGET"
+  fi
+  ABS_PATH="$(cd "$TARGET" && pwd)"
+  SESSION_NAME="$(basename "$ABS_PATH")"
+
+  # Attach to existing session if one already exists with this name
+  if tmux has-session -t "=$SESSION_NAME" 2>/dev/null; then
+    exec tmux attach-session -t "=$SESSION_NAME"
+  fi
+
+  # Create new session with a locked "root" window, then attach
+  tmux new-session -d -s "$SESSION_NAME" -n "root" -c "$ABS_PATH"
+  tmux set-window-option -t "$SESSION_NAME:root" automatic-rename off
+  exec tmux attach-session -t "$SESSION_NAME"
+fi
 
 # Create directory if it doesn't exist
 if [ ! -d "$TARGET" ]; then

--- a/scripts/.bin/txcd
+++ b/scripts/.bin/txcd
@@ -11,6 +11,10 @@ fi
 TARGET="$1"
 
 # Resolve/create the directory (shared by both branches)
+if [ -e "$TARGET" ] && [ ! -d "$TARGET" ]; then
+  echo "txcd: target exists and is not a directory: $TARGET" >&2
+  exit 1
+fi
 if [ ! -d "$TARGET" ]; then
   mkdir -p -- "$TARGET"
 fi
@@ -27,7 +31,7 @@ if [ -z "${TMUX:-}" ]; then
   # Create new session with a locked "root" window, then attach
   tmux new-session -d -s "$SESSION_NAME" -n "root" -c "$ABS_PATH"
   tmux set-window-option -t "$SESSION_NAME:root" automatic-rename off
-  exec tmux attach-session -t "$SESSION_NAME"
+  exec tmux attach-session -t "=$SESSION_NAME"
 fi
 
 # Get the session root directory
@@ -38,10 +42,10 @@ if [[ "$ABS_PATH" == "$SESSION_ROOT" ]]; then
   WINDOW_NAME="."
 elif [[ "$ABS_PATH" == "$SESSION_ROOT/"* ]]; then
   WINDOW_NAME="${ABS_PATH#"$SESSION_ROOT/"}"
-elif [[ "$ABS_PATH" == "$HOME" ]]; then
+elif [[ "$ABS_PATH" == "${HOME:-}" ]] && [ -n "${HOME:-}" ]; then
   WINDOW_NAME="~"
-elif [[ "$ABS_PATH" == "$HOME/"* ]]; then
-  WINDOW_NAME="~/${ABS_PATH#"$HOME/"}"
+elif [ -n "${HOME:-}" ] && [[ "$ABS_PATH" == "${HOME}/"* ]]; then
+  WINDOW_NAME="~/${ABS_PATH#"${HOME}/"}"
 else
   WINDOW_NAME="$ABS_PATH"
 fi

--- a/scripts/.bin/txcd
+++ b/scripts/.bin/txcd
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+set -u
+set -o pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: txcd <directory>" >&2
+  exit 1
+fi
+
+if [ -z "${TMUX:-}" ]; then
+  echo "txcd: must be run inside a tmux session" >&2
+  exit 1
+fi
+
+TARGET="$1"
+
+# Create directory if it doesn't exist
+if [ ! -d "$TARGET" ]; then
+  mkdir -p -- "$TARGET"
+fi
+
+# Resolve absolute path
+ABS_PATH="$(cd "$TARGET" && pwd)"
+
+# Get the session root directory
+SESSION_ROOT="$(tmux display-message -p "#{session_path}")"
+
+# Compute window name: relative to session root, ~-relative, or absolute
+if [[ "$ABS_PATH" == "$SESSION_ROOT" ]]; then
+  WINDOW_NAME="."
+elif [[ "$ABS_PATH" == "$SESSION_ROOT/"* ]]; then
+  WINDOW_NAME="${ABS_PATH#"$SESSION_ROOT/"}"
+elif [[ "$ABS_PATH" == "$HOME" ]]; then
+  WINDOW_NAME="~"
+elif [[ "$ABS_PATH" == "$HOME/"* ]]; then
+  WINDOW_NAME="~/${ABS_PATH#"$HOME/"}"
+else
+  WINDOW_NAME="$ABS_PATH"
+fi
+
+# If a window with this name already exists, switch to it
+if tmux select-window -t "=$WINDOW_NAME" 2>/dev/null; then
+  exit 0
+fi
+
+# Create and switch to a new window, locking the name
+tmux new-window -n "$WINDOW_NAME" -c "$ABS_PATH"
+tmux set-window-option automatic-rename off

--- a/scripts/.bin/txcd
+++ b/scripts/.bin/txcd
@@ -37,9 +37,16 @@ fi
 # Get the session root directory
 SESSION_ROOT="$(tmux display-message -p "#{session_path}")"
 
+# Normalize session root: strip trailing slash unless it is exactly "/"
+if [[ "$SESSION_ROOT" != "/" ]]; then
+  SESSION_ROOT="${SESSION_ROOT%/}"
+fi
+
 # Compute window name: relative to session root, ~-relative, or absolute
 if [[ "$ABS_PATH" == "$SESSION_ROOT" ]]; then
   WINDOW_NAME="."
+elif [[ "$SESSION_ROOT" == "/" ]] && [[ "$ABS_PATH" == /* ]]; then
+  WINDOW_NAME="${ABS_PATH#/}"
 elif [[ "$ABS_PATH" == "$SESSION_ROOT/"* ]]; then
   WINDOW_NAME="${ABS_PATH#"$SESSION_ROOT/"}"
 elif [[ "$ABS_PATH" == "${HOME:-}" ]] && [ -n "${HOME:-}" ]; then


### PR DESCRIPTION
Adds `txcd` — a script to open a tmux window at a given directory.

## Behaviour

**Inside tmux:**
- Creates a new window named after the target directory
  - Relative to session root if it is a child of it
  - `~`-relative if under `$HOME`
  - Absolute path otherwise
- Switches focus to the new window with `automatic-rename` locked
- If a window with that name already exists, switches to it instead
- Creates the directory if it does not exist

**Outside tmux:**
- Creates a new session named after the directory basename, with a locked `root` window cding into the target
- If a session with that name already exists, attaches to it
- Creates the directory if it does not exist

## Examples

```
$ txcd neovim/.config/nvim/   # window named neovim/.config/nvim
$ txcd ~/.copilot/skills       # window named ~/.copilot/skills
$ txcd /tmp/scratch            # window named /tmp/scratch
```

---

@copilot Please provide a **complete and exhaustive review in a single pass** — include all issues, edge cases, and suggestions at once rather than across multiple rounds.