### PR TITLE
chore: remove global gitignore of skills artefacts

### DIFF
--- a/git/.gitignore_global
+++ b/git/.gitignore_global
@@ -8,8 +8,4 @@ CLAUDE.md
 
 ralph.toml
 
-docs/agents/
-.scratch/
-.out-of-scope/
-
 **/.claude/settings.local.json


### PR DESCRIPTION
## What & why

Removes the `docs/agents/`, `.scratch/`, and `.out-of-scope/` entries from `git/.gitignore_global`, added in a83066e to keep mattpocock/skills' per-developer artefacts out of shared repo history. Those entries are no longer relevant and are being reverted.

## Ticket

NOTICKET

## How to test

`git/.gitignore_global` is symlinked to `~/.gitignore_global` via stow; diff the file to confirm only the three lines (plus the surrounding blank line) added in a83066e are removed, and `**/.claude/settings.local.json` (added later, in 1a5ecd8) is untouched.

## Risk / rollout

None — this only affects what git ignores globally, no runtime behaviour.
